### PR TITLE
Exclude trailing parenthesis from URL

### DIFF
--- a/src/Autolink.php
+++ b/src/Autolink.php
@@ -126,6 +126,11 @@ class Autolink
                     $url = substr($url, 0, -1);
                 }
 
+                if (str_ends_with($url, ')')) {
+                    $suffix = ')';
+                    $url = substr($url, 0, -1);
+                }
+
                 return $this->link($url, $attribs) . $suffix;
             },
             $text


### PR DESCRIPTION
I found that when a link was enclosed in parentheses, e.g., (https://google.com), the opening parenthesis was correctly excluded from the URL, but the closing one was included. This is fixed here using the same pattern that excludes closing periods, but there may be a better way (either earlier in the regex, or maybe the exclusions should be in a foreach loop).